### PR TITLE
Add UncheckedBase and CheckedBase to support CRUD requests in Advance…

### DIFF
--- a/src/requests/checked/checked_base.py
+++ b/src/requests/checked/checked_base.py
@@ -1,0 +1,34 @@
+from src.api.requests.crud_interface import CrudInterface
+from src.api.requests.request import Request
+from src.requests.unchecked.unchecked_base import UncheckedBase
+from src.enums.endpoint import Endpoint
+from src.api.models.base_model import BaseModel
+import requests
+import pytest
+
+class CheckedBase(Request, CrudInterface):
+    """Шаблон для проверяемых запросов CRUD эндпоинтов."""
+    
+    def __init__(self, spec: requests.Session, endpoint: Endpoint):
+        super().__init__(spec, endpoint)
+        self.unchecked_base = UncheckedBase(spec, endpoint)
+    
+    def create(self, model: dict) -> BaseModel:
+        response = self.unchecked_base.create(model)
+        pytest.assume(response.status_code == 200, f"Expected status 200, got {response.status_code}: {response.text}")
+        return self.endpoint.model_class(**response.json())
+    
+    def read(self, id: str) -> BaseModel:
+        response = self.unchecked_base.read(id)
+        pytest.assume(response.status_code == 200, f"Expected status 200, got {response.status_code}: {response.text}")
+        return self.endpoint.model_class(**response.json())
+    
+    def update(self, id: str, model: dict) -> BaseModel:
+        response = self.unchecked_base.update(id, model)
+        pytest.assume(response.status_code == 200, f"Expected status 200, got {response.status_code}: {response.text}")
+        return self.endpoint.model_class(**response.json())
+    
+    def delete(self, id: str) -> str:
+        response = self.unchecked_base.delete(id)
+        pytest.assume(response.status_code == 200, f"Expected status 200, got {response.status_code}: {response.text}")
+        return response.text

--- a/src/requests/unchecked/unchecked_base.py
+++ b/src/requests/unchecked/unchecked_base.py
@@ -1,0 +1,32 @@
+from src.api.requests.crud_interface import CrudInterface
+from src.api.requests.request import Request
+from src.enums.endpoint import Endpoint
+import requests
+
+class UncheckedBase(Request, CrudInterface):
+    """Шаблон для непроверяемых запросов CRUD эндпоинтов."""
+    
+    def __init__(self, spec: requests.Session, endpoint: Endpoint):
+        super().__init__(spec, endpoint)
+    
+    def create(self, model: dict) -> requests.Response:
+        return self.spec.post(
+            self.endpoint.url,
+            json=model
+        )
+    
+    def read(self, id: str) -> requests.Response:
+        return self.spec.get(
+            f"{self.endpoint.url}/id:{id}"
+        )
+    
+    def update(self, id: str, model: dict) -> requests.Response:
+        return self.spec.put(
+            f"{self.endpoint.url}/id:{id}",
+            json=model
+        )
+    
+    def delete(self, id: str) -> requests.Response:
+        return self.spec.delete(
+            f"{self.endpoint.url}/id:{id}"
+        )


### PR DESCRIPTION
- Разделены сущности по пакетам (api/models, api/requests, api/specs).
- Использованы DTO с pydantic для валидации и сериализации данных вместо JSON.
- Добавлена генерация тестовых данных с помощью faker.
- Улучшены тесты с проверкой тела ответа (id, name, locator) для всех операций.
- Сохранены тесты на запуск билда с echo "Hello, world!", мокированный тест, и поиск проекта по имени.
- Добавлены UncheckedBase и CheckedBase для поддержки CRUD запросов.
- Применены практики Allure, pytest, и requests-mock для тестирования.